### PR TITLE
Bump lychee version 6.0.2 to 7.1.1

### DIFF
--- a/io.mango3d.LycheeSlicer.metainfo.xml
+++ b/io.mango3d.LycheeSlicer.metainfo.xml
@@ -34,6 +34,8 @@
   </content_rating>
 
   <releases>
+    <release version="7.1.1" date="2024-10-29">
+    </release>
     <release version="6.0.2" date="2024-04-16">
     </release>
     <release version="5.4.3" date="2023-11-29">

--- a/io.mango3d.LycheeSlicer.yml
+++ b/io.mango3d.LycheeSlicer.yml
@@ -32,10 +32,10 @@ modules:
       - install -Dm755 apply_extra /app/bin/apply_extra
     sources:
       - type: extra-data
-        url: https://mango-lychee.nyc3.cdn.digitaloceanspaces.com/LycheeSlicer-6.2.0.deb
+        url: https://mango-lychee.nyc3.cdn.digitaloceanspaces.com/LycheeSlicer-7.1.1.deb
         filename: lychee.deb
-        sha256: ba2db0cb8a01d5d3729c7c841ae1ff81a0bdea90fc744274675710cfb7d3aa47
-        size: 120493584
+        sha256: 61ca262560d9d7de0210d2664de4b2f767e236b47394861cfb9b818b8c794803
+        size: 121600188
       - type: file
         path: io.mango3d.LycheeSlicer.metainfo.xml
       - type: file


### PR DESCRIPTION
Mango3D released Lychee Slicer version 7.1.1 on 2024-10-29.
Version 7.1.2 is also already released but is heavily discussed on the Lychee Discord for introducing major bugs. 